### PR TITLE
fix: get the latest tag for push events

### DIFF
--- a/node/dist/index.js
+++ b/node/dist/index.js
@@ -114,7 +114,9 @@ module.exports = async function getVersion(
       versionTag = argInceptionVersionTag
     } else {
       // get the latest tag
-      let latestTag = matchingTags.data[0].name
+      let latestTagRef = matchingTags.data[0].ref // e.g. refs/tags/v1.2.3
+      core.debug('latestTagRef[' + latestTagRef + ']')
+      let latestTag = latestTagRef.replace('refs/tags/', '') // e.g. v1.2.3
       core.debug('latestTag[' + latestTag + ']')
       // ensure we have a valid semver tag
       let tagSemVer = semverClean(latestTag)

--- a/node/lib/get-version.js
+++ b/node/lib/get-version.js
@@ -108,7 +108,9 @@ module.exports = async function getVersion(
       versionTag = argInceptionVersionTag
     } else {
       // get the latest tag
-      let latestTag = matchingTags.data[0].name
+      let latestTagRef = matchingTags.data[0].ref // e.g. refs/tags/v1.2.3
+      core.debug('latestTagRef[' + latestTagRef + ']')
+      let latestTag = latestTagRef.replace('refs/tags/', '') // e.g. v1.2.3
       core.debug('latestTag[' + latestTag + ']')
       // ensure we have a valid semver tag
       let tagSemVer = semverClean(latestTag)

--- a/tests/get-version.spec.js
+++ b/tests/get-version.spec.js
@@ -79,8 +79,11 @@ describe("get-version.js", async function () {
     }
     // Mock core module to avoid actual core.info/debug calls
     const coreMock = {
+      startGroup: () => {},
+      endGroup: () => {},
       debug: () => {},
       info: () => {},
+      warning: () => {},
       setFailed: () => {}
     }
     // Use proxyquire to inject mocks
@@ -126,8 +129,11 @@ describe("get-version.js", async function () {
     }
     // Mock core module to avoid actual core.info/debug calls
     const coreMock = {
+      startGroup: () => {},
+      endGroup: () => {},
       debug: () => {},
       info: () => {},
+      warning: () => {},
       setFailed: () => {}
     }
     // Use proxyquire to inject mocks
@@ -178,8 +184,11 @@ describe("get-version.js", async function () {
     }
     // Mock core module to avoid actual core.info/debug calls
     const coreMock = {
+      startGroup: () => {},
+      endGroup: () => {},
       debug: () => {},
       info: () => {},
+      warning: () => {},
       setFailed: () => {}
     }
     // Use proxyquire to inject mocks
@@ -225,8 +234,11 @@ describe("get-version.js", async function () {
     }
     // Mock core module to avoid actual core.info/debug calls
     const coreMock = {
+      startGroup: () => {},
+      endGroup: () => {},
       debug: () => {},
       info: () => {},
+      warning: () => {},
       setFailed: () => {}
     }
     // Use proxyquire to inject mocks
@@ -293,8 +305,11 @@ describe("get-version.js", async function () {
     }
     // Mock core module to avoid actual core.info/debug calls
     const coreMock = {
+      startGroup: () => {},
+      endGroup: () => {},
       debug: () => {},
       info: () => {},
+      warning: () => {},
       setFailed: () => {}
     }
     // Use proxyquire to inject mocks
@@ -347,7 +362,6 @@ describe("get-version.js", async function () {
             data: [
               {
                 ref: "refs/tags/" + latestTagName,
-                name: latestTagName,
                 object: {
                   sha: beforeCommitSha
                 }
@@ -390,6 +404,8 @@ describe("get-version.js", async function () {
     
     // Mock core module to avoid actual core.info/debug calls
     const coreMock = {
+      startGroup: () => {},
+      endGroup: () => {},
       debug: () => {},
       info: () => {},
       warning: () => {},
@@ -481,6 +497,8 @@ describe("get-version.js", async function () {
     
     // Mock core module to avoid actual core.info/debug calls
     const coreMock = {
+      startGroup: () => {},
+      endGroup: () => {},
       debug: () => {},
       info: () => {},
       warning: () => {},

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -1,4 +1,5 @@
 // BOF
+const { group } = require("node:console");
 const path = require("node:path");
 // project directories
 const dirRoot = path.normalize(__dirname + path.sep + "..");
@@ -76,10 +77,14 @@ describe("index.js", async function () {
           default: return ''
         }
       },
+      startGroup: () => {},
+      endGroup: () => {},
       setOutput: () => {},
       setSecret: () => {},
       debug: () => {},
-      info: () => {}
+      info: () => {},
+      warning: () => {},
+      setFailed: () => {}
     }
     // Use proxyquire to inject mocks
     const main = proxyquire(modulePath, {
@@ -120,8 +125,11 @@ describe("index.js", async function () {
           default: return ''
         }
       },
+      startGroup: () => {},
+      endGroup: () => {},
       debug: () => {},
       info: () => {},
+      warning: () => {},
       setSecret: () => {},
       setOutput: () => {},
       setFailed: () => {}
@@ -160,8 +168,11 @@ describe("index.js", async function () {
           default: return ''
         }
       },
+      startGroup: () => {},
+      endGroup: () => {},
       debug: () => {},
       info: () => {},
+      warning: () => {},
       setSecret: () => {},
       setOutput: () => {},
       setFailed: () => {}
@@ -197,8 +208,11 @@ describe("index.js", async function () {
           default: return ''
         }
       },
+      startGroup: () => {},
+      endGroup: () => {},
       debug: () => {},
       info: () => {},
+      warning: () => {},
       setSecret: () => {},
       setOutput: () => {},
       setFailed: () => {}
@@ -238,8 +252,11 @@ describe("index.js", async function () {
           default: return ''
         }
       },
+      startGroup: () => {},
+      endGroup: () => {},
       debug: () => {},
       info: () => {},
+      warning: () => {},
       setSecret: () => {},
       setOutput: () => {},
       setFailed: () => {}


### PR DESCRIPTION
# Feature Details

- [listMatchingRefs](https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28) no longer returning `name` , updated to use `ref` and parse tag name
- update unit test to reflect REST API endpoints for Git references
- added mock for `startGroup` and `endGroup` core module 