### PR TITLE
add outputs for build job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,8 @@ jobs:
           node/package-lock.json
           README.md
           action.yml
+    outputs:
+      versionTag: ${{ steps.build-version.outputs.versionTag }}
   # --------------------------------------------
   test:
     name: Artifact Release


### PR DESCRIPTION
# Feature details

- add `outputs` spec to the `release` build job 